### PR TITLE
fix: remove `contributions` section

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -2,7 +2,6 @@ import { Head } from "$fresh/runtime.ts";
 import Navbar from "~/islands/Navbar.tsx";
 import Hero from "~/islands/Hero.tsx";
 import Footer from "~/components/Footer.tsx";
-import Contributions from "~/islands/Contributions.tsx";
 import Section from "~/components/Section.tsx";
 import { about, awards, contact, projects } from "~/misc.ts";
 
@@ -33,7 +32,6 @@ export default function Home() {
           description="Some of my hackathon feats."
           items={awards}
         />
-        <Contributions />
         <Section
           id="contact"
           title="Contact"


### PR DESCRIPTION
This PR removes the `<Contributions />` component that is currently broken.

GitHub now uses client side markup to render their contribution graph. Thus, the endpoint I was using has been deleted, resulting in the graph not showing.