### PR TITLE
fix: use `font` files from `cdn`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,6 @@
     "resvg-wasm": "npm:@resvg/resvg-wasm@^2.6.2",
     "$std/": "https://deno.land/std@0.202.0/",
     "vite": "npm:vite@^7.2.6",
-    "vite-plugin-arraybuffer": "npm:vite-plugin-arraybuffer@^0.1.1",
     "~/": "./",
     "fresh": "jsr:@fresh/core@^2.2.0"
   },

--- a/routes/api/og.ts
+++ b/routes/api/og.ts
@@ -4,7 +4,7 @@ import { Context } from "fresh";
 async function getImage(): Promise<
   { data: ArrayBuffer; etag: string }
 > {
-  const raw = generateOGImage();
+  const raw = await generateOGImage();
   const uint8 = new Uint8Array(raw);
 
   const hashBuffer = await crypto.subtle.digest("SHA-256", uint8);

--- a/utils/og-generator.tsx
+++ b/utils/og-generator.tsx
@@ -23,13 +23,30 @@ interface OGCardProps {
   location: string;
 }
 
-const OGCard = ({
-  name,
-  company,
-  stat1,
-  stat2,
-  location,
-}: OGCardProps) => {
+const CLIENT_ASSET_BASE = new URL("../../client", import.meta.url);
+
+const normalizeAssetPath = (assetPath: string) =>
+  assetPath.startsWith("/") ? assetPath.slice(1) : assetPath;
+
+const toClientAssetUrl = (assetPath: string): URL =>
+  new URL(normalizeAssetPath(assetPath), CLIENT_ASSET_BASE);
+
+async function loadBinary(url: URL): Promise<Uint8Array> {
+  const response = await fetch(url).catch(() => undefined);
+  if (response?.ok) {
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  return await Deno.readFile(url);
+}
+
+function loadFontBuffers(fontPaths: string[]): Promise<Uint8Array[]> {
+  return Promise.all(
+    fontPaths.map((path) => loadBinary(toClientAssetUrl(path))),
+  );
+}
+
+const OGCard = ({ name, company, stat1, stat2, location }: OGCardProps) => {
   const bgColor = "rgb(18, 24, 39)";
   const textColor = "#ffffff";
 
@@ -158,10 +175,9 @@ const OGCard = ({
   );
 };
 
-export function generateOGImage() {
-  const CardWrapper = () => <OGCard {...OG_DATA} />;
-
-  const finalSvg = render(<CardWrapper />);
+export async function generateOGImage() {
+  const finalSvg = render(<OGCard {...OG_DATA} />);
+  const fontBuffers = await loadFontBuffers([InterBold, InterSemiBold]);
 
   const resvg = new Resvg(finalSvg, {
     dpi: 100,
@@ -170,10 +186,7 @@ export function generateOGImage() {
     textRendering: 2,
     fitTo: { mode: "zoom", value: 2 },
     font: {
-      fontBuffers: [
-        new Uint8Array(InterBold),
-        new Uint8Array(InterSemiBold),
-      ],
+      fontBuffers,
       defaultFontFamily: "Inter",
       loadSystemFonts: false,
     },

--- a/utils/og-generator.tsx
+++ b/utils/og-generator.tsx
@@ -4,8 +4,11 @@ import IconBrandTypescript from "$icons/brand-typescript.tsx";
 import IconBrandPython from "$icons/brand-python.tsx";
 import IconBrandCoinbase from "$icons/brand-coinbase.tsx";
 import BrandHaskell from "~/components/BrandHaskell.tsx";
-import InterBold from "../static/fonts/Inter-Bold.woff2?arraybuffer";
-import InterSemiBold from "../static/fonts/Inter-SemiBold.woff2?arraybuffer";
+
+const FONT_URLS = [
+  "https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-700-normal.woff2",
+  "https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-600-normal.woff2",
+];
 
 export const OG_DATA = {
   name: "Javier Ríos Urbano",
@@ -23,27 +26,16 @@ interface OGCardProps {
   location: string;
 }
 
-const CLIENT_ASSET_BASE = new URL("../../client", import.meta.url);
-
-const normalizeAssetPath = (assetPath: string) =>
-  assetPath.startsWith("/") ? assetPath.slice(1) : assetPath;
-
-const toClientAssetUrl = (assetPath: string): URL =>
-  new URL(normalizeAssetPath(assetPath), CLIENT_ASSET_BASE);
-
-async function loadBinary(url: URL): Promise<Uint8Array> {
-  const response = await fetch(url).catch(() => undefined);
-  if (response?.ok) {
-    return new Uint8Array(await response.arrayBuffer());
+async function fetchBinary(url: string): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch font at ${url}: ${response.status}`);
   }
-
-  return await Deno.readFile(url);
+  return new Uint8Array(await response.arrayBuffer());
 }
 
-function loadFontBuffers(fontPaths: string[]): Promise<Uint8Array[]> {
-  return Promise.all(
-    fontPaths.map((path) => loadBinary(toClientAssetUrl(path))),
-  );
+function loadFontBuffers(fontUrls: string[]): Promise<Uint8Array[]> {
+  return Promise.all(fontUrls.map(fetchBinary));
 }
 
 const OGCard = ({ name, company, stat1, stat2, location }: OGCardProps) => {
@@ -177,7 +169,7 @@ const OGCard = ({ name, company, stat1, stat2, location }: OGCardProps) => {
 
 export async function generateOGImage() {
   const finalSvg = render(<OGCard {...OG_DATA} />);
-  const fontBuffers = await loadFontBuffers([InterBold, InterSemiBold]);
+  const fontBuffers = await loadFontBuffers(FONT_URLS);
 
   const resvg = new Resvg(finalSvg, {
     dpi: 100,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,10 @@
 import { defineConfig } from "vite";
 import { fresh } from "@fresh/plugin-vite";
 import tailwindcss from "@tailwindcss/vite";
-import arraybuffer from "vite-plugin-arraybuffer";
 
 export default defineConfig({
   plugins: [
     fresh(),
     tailwindcss({ optimize: true }),
-    arraybuffer(),
-  ],
-  assetsInclude: [
-    "./static/fonts/*.woff2",
   ],
 });


### PR DESCRIPTION
~~This PR fixes a bug where the `og` image did not have any font. This was caused by `vite` only outputting `asset` files to the client `build`, and then providing the path of the `asset` relative to the client build for the `ssr` to resolve manually, which is exactly what this PR does.~~

This PR uses font files from `jsdelivr.net`. It is cumbersome to load static assets in `ssr` mode, so we cut the problem altogether by fetching them on demand.